### PR TITLE
Update admin-settings.php

### DIFF
--- a/src/views/admin-settings.php
+++ b/src/views/admin-settings.php
@@ -18,7 +18,7 @@
 			            wp_enqueue_style('gravityforms-plugin', plugins_url('../assets/css/style.css', __FILE__));
 			            $pairing_form = file_get_contents(plugin_dir_url(__FILE__).'../templates/pairing.tpl');
 			            $token_format = file_get_contents(plugin_dir_url(__FILE__).'../templates/token.tpl');
-                        if (true === empty(get_option('bitpayToken'))) {
+                        if (false !== get_option('bitpayToken')) {
                             echo sprintf($pairing_form, 'visible');
                             echo sprintf($token_format, 'hidden', plugins_url('../assets/img/logo.png', __FILE__),'','');
                         } else {


### PR DESCRIPTION
PHP 5.4 requires a variable to be used for the empty() function, but the get_option from WordPress returns a value which causes the settings page to return blank. Switched to using a boolean false check on the get_option function returned value.